### PR TITLE
Update web sockets server example error

### DIFF
--- a/files/en-us/web/api/websockets_api/writing_websocket_server/index.md
+++ b/files/en-us/web/api/websockets_api/writing_websocket_server/index.md
@@ -296,7 +296,7 @@ class Server {
                     // To test the below code, we need to manually buffer larger messages — since the NIC's autobuffering 
                     // may be too latency-friendly for this code to run (that is, we may have only some of the bytes in this
                     // websocket frame available through client.Available).  
-                    msglen = BitConverter.ToUInt64(new byte[] { data[9], data[8], data[7], data[6], data[5], data[4], data[3], data[2] });
+                    msglen = BitConverter.ToUInt64(new byte[] { bytes[9], bytes[8], bytes[7], bytes[6], bytes[5], bytes[4], bytes[3], bytes[2] },0);
                     offset = 10;
                 }
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
In reference to #17204 the BitConverter.ToUInt64 Method is missing a necessary parameter `startIndex`.
#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
This proposed change with the addition of a `startIndex` corrects the example error.
#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
https://docs.microsoft.com/en-us/dotnet/api/system.bitconverter.touint64?view=net-6.0
#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata

- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
